### PR TITLE
fix: remove requiring of missing `custom.utils`

### DIFF
--- a/doc/rules/elixir/pipe_first_function_argument.md
+++ b/doc/rules/elixir/pipe_first_function_argument.md
@@ -6,7 +6,6 @@
 <summary><strong>Show</strong></summary>
 
 ```lua
-local _utils = require("custom.utils")
 local utils = require("alternative.utils")
 local ignore_built_in_functions = [[(#not-any-of? @function_name "if" "case" "cond" "with" "def" "defp" "defmacro")]]
 

--- a/doc/rules/lua/wrap_it_test_in_describe.md
+++ b/doc/rules/lua/wrap_it_test_in_describe.md
@@ -6,7 +6,6 @@
 <summary><strong>Show</strong></summary>
 
 ```lua
-local utils = require("custom.utils")
 local utils = require("alternative.utils")
 
 return {

--- a/lua/alternative/rules/elixir/pipe_first_function_argument.lua
+++ b/lua/alternative/rules/elixir/pipe_first_function_argument.lua
@@ -1,4 +1,3 @@
-local _utils = require("custom.utils")
 local utils = require("alternative.utils")
 local ignore_built_in_functions = [[(#not-any-of? @function_name "if" "case" "cond" "with" "def" "defp" "defmacro")]]
 

--- a/lua/alternative/rules/lua/wrap_it_test_in_describe.lua
+++ b/lua/alternative/rules/lua/wrap_it_test_in_describe.lua
@@ -1,4 +1,3 @@
-local utils = require("custom.utils")
 local utils = require("alternative.utils")
 
 return {


### PR DESCRIPTION
The plugin is crashing on load due to the attempt to require `custom.utils`. Removing the lines results in the plugin loading.

Considering that the requires are either assigned to an underscore variable, or assigned to `utils` and then overwritten right after, I'm guessing that these lines are OK to remove.

Please correct me if I've misunderstood the code and these lines need to be altered in some other way.